### PR TITLE
Refactor flag support

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/braintree-go/braintree-go/testhelpers"
@@ -76,10 +77,14 @@ func testSubMerchantAccount() string {
 	return merchantAccount.Id
 }
 
-func init() {
-	logEnabled := flag.Bool("log", false, "enables logging")
+var logEnabled = flag.Bool("log", false, "enables logging")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
 
 	if *logEnabled {
 		testGateway.Logger = log.New(os.Stderr, "", 0)
 	}
+
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
### Description
Running `flag.Parse` inside an `init()` was never the correct way to do flag parsing. We were always supposed to be putting it in `func TestMain()`. Eventually `go1.13` broke this behavior.

This refactors the flag usage to make it consistent with how Golang intended flags to be used.

### Checklist
<!-- Tick with "x" the boxes that apply. You can also fill these out after creating the PR. -->
* [x] I've read the [contribution guidelines](CONTRIBUTING.md)
* [x] I've added Unit Tests if necessary.
* [x] I've checked whether additional documentation is needed.
* [x] I've ensured any personally identifying information is handled with the necessary care.
* [x] I've checked if my implementation doesn't break other features.

