### PR TITLE
Feature/[FINCC-4051] Check Paypal billing agreement when verifying with existing PMT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/hellofresh/braintree-go
 
 go 1.14
+
+require github.com/braintree-go/braintree-go v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/braintree-go/braintree-go v0.22.0 h1:tSMs8IQ2I38RzOsQ/kn1lnL/XWQ/wCTa/XHdcb8760o=
+github.com/braintree-go/braintree-go v0.22.0/go.mod h1:KZOsgcN57OCLvNAegsEDssgYSsGbdL+msvex1SNmb0E=

--- a/paypal_account.go
+++ b/paypal_account.go
@@ -13,6 +13,7 @@ type PayPalAccount struct {
 	ImageURL      string                `xml:"image-url,omitempty"`
 	CreatedAt     *time.Time            `xml:"created-at,omitempty"`
 	UpdatedAt     *time.Time            `xml:"updated-at,omitempty"`
+	RevokedAt     *time.Time            `xml:"revoked-at,omitempty"`
 	Subscriptions *Subscriptions        `xml:"subscriptions,omitempty"`
 	Default       bool                  `xml:"default,omitempty"`
 	Options       *PayPalAccountOptions `xml:"options,omitempty"`
@@ -51,6 +52,11 @@ func (paypalAccount *PayPalAccount) IsDefault() bool {
 
 func (paypalAccount *PayPalAccount) GetImageURL() string {
 	return paypalAccount.ImageURL
+}
+
+// GetRevokedAt returns the revoked at time
+func (paypalAccount *PayPalAccount) GetRevokedAt() *time.Time {
+	return paypalAccount.RevokedAt
 }
 
 // AllSubscriptions returns all subscriptions for this paypal account, or nil if none present.


### PR DESCRIPTION
### Description
When doing Paypal verification as an existing payment method (i.e. in the reactivation flow), we need to check if the customer has an active billing agreement in Paypal.

Brain Tree provides revokedAt field for PayPalAccount which can be used to check if the agreement active or not. 
[docs](https://developers.braintreepayments.com/reference/response/paypal-account/ruby#revoked_at)

### Checklist
<!-- Tick with "x" the boxes that apply. You can also fill these out after creating the PR. -->
* [x] I've read the [contribution guidelines](CONTRIBUTING.md)
* [x] I've added Unit Tests if necessary.
* [x] I've checked whether additional documentation is needed.
* [x] I've ensured any personally identifying information is handled with the necessary care.
* [x] I've checked if my implementation doesn't break other features.

