### PR TITLE
Enable Venmo Transaction Options

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -206,6 +206,7 @@ type TransactionOptions struct {
 	StoreShippingAddressInVault      bool                                   `xml:"store-shipping-address-in-vault,omitempty"`
 	HoldInEscrow                     bool                                   `xml:"hold-in-escrow,omitempty"`
 	TransactionOptionsPaypalRequest  *TransactionOptionsPaypalRequest       `xml:"paypal,omitempty"`
+	TransactionOptionsVenmoRequest   *TransactionOptionsVenmoRequest        `xml:"venmo,omitempty"`
 	SkipAdvancedFraudChecking        bool                                   `xml:"skip_advanced_fraud_checking,omitempty"`
 	ThreeDSecure                     *TransactionOptionsThreeDSecureRequest `xml:"three-d-secure,omitempty"`
 }
@@ -215,6 +216,10 @@ type TransactionOptionsPaypalRequest struct {
 	PayeeEmail        string
 	Description       string
 	SupplementaryData map[string]string
+}
+
+type TransactionOptionsVenmoRequest struct {
+	ProfileId string
 }
 
 func (r TransactionOptionsPaypalRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/transaction.go
+++ b/transaction.go
@@ -219,7 +219,7 @@ type TransactionOptionsPaypalRequest struct {
 }
 
 type TransactionOptionsVenmoRequest struct {
-	ProfileId string
+	ProfileId string `xml:"profile-id"`
 }
 
 func (r TransactionOptionsPaypalRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/transaction_venmo_account_details_integration_test.go
+++ b/transaction_venmo_account_details_integration_test.go
@@ -52,57 +52,6 @@ func TestTransactionVenmoAccountDetails(t *testing.T) {
 	}
 }
 
-const profileId = "venmoProfileId"
-
-func TestTransactionVenmoAccountDetailsWithOptions(t *testing.T) {
-	ctx := context.Background()
-
-	tx, err := testGateway.Transaction().Create(ctx, &TransactionRequest{
-		Type:               "sale",
-		Amount:             NewDecimal(2000, 2),
-		PaymentMethodNonce: FakeNonceVenmoAccount,
-		Options: &TransactionOptions{
-			TransactionOptionsVenmoRequest: &TransactionOptionsVenmoRequest{
-				ProfileId: profileId,
-			},
-		},
-	})
-
-	t.Log(tx)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tx.Id == "" {
-		t.Fatal("Received invalid ID on new transaction")
-	}
-	if tx.Status != TransactionStatusAuthorized {
-		t.Fatal(tx.Status)
-	}
-
-	if tx.VenmoAccountDetails == nil {
-		t.Fatal("Expected VenmoAccountDetails for transaction created with VenmoAccount nonce")
-	}
-
-	t.Log(tx.VenmoAccountDetails)
-
-	if tx.VenmoAccountDetails.Token != "" {
-		t.Fatal("Expected VenmoAccountDetails to not have Token set")
-	}
-	if tx.VenmoAccountDetails.Username == "" {
-		t.Fatal("Expected VenmoAccountDetails to have Username set")
-	}
-	if tx.VenmoAccountDetails.VenmoUserID == "" {
-		t.Fatal("Expected VenmoAccountDetails to have VenmoUserID set")
-	}
-	if tx.VenmoAccountDetails.SourceDescription == "" {
-		t.Fatal("Expected VenmoAccountDetails to have SourceDescription set")
-	}
-	if tx.VenmoAccountDetails.ImageURL == "" {
-		t.Fatal("Expected VenmoAccountDetails to have ImageURL set")
-	}
-}
-
 func TestTransactionWithoutVenmoAccountDetails(t *testing.T) {
 	ctx := context.Background()
 

--- a/transaction_venmo_account_details_integration_test.go
+++ b/transaction_venmo_account_details_integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package braintree
@@ -14,6 +15,57 @@ func TestTransactionVenmoAccountDetails(t *testing.T) {
 		Type:               "sale",
 		Amount:             NewDecimal(2000, 2),
 		PaymentMethodNonce: FakeNonceVenmoAccount,
+	})
+
+	t.Log(tx)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tx.Id == "" {
+		t.Fatal("Received invalid ID on new transaction")
+	}
+	if tx.Status != TransactionStatusAuthorized {
+		t.Fatal(tx.Status)
+	}
+
+	if tx.VenmoAccountDetails == nil {
+		t.Fatal("Expected VenmoAccountDetails for transaction created with VenmoAccount nonce")
+	}
+
+	t.Log(tx.VenmoAccountDetails)
+
+	if tx.VenmoAccountDetails.Token != "" {
+		t.Fatal("Expected VenmoAccountDetails to not have Token set")
+	}
+	if tx.VenmoAccountDetails.Username == "" {
+		t.Fatal("Expected VenmoAccountDetails to have Username set")
+	}
+	if tx.VenmoAccountDetails.VenmoUserID == "" {
+		t.Fatal("Expected VenmoAccountDetails to have VenmoUserID set")
+	}
+	if tx.VenmoAccountDetails.SourceDescription == "" {
+		t.Fatal("Expected VenmoAccountDetails to have SourceDescription set")
+	}
+	if tx.VenmoAccountDetails.ImageURL == "" {
+		t.Fatal("Expected VenmoAccountDetails to have ImageURL set")
+	}
+}
+
+const profileId = "venmoProfileId"
+
+func TestTransactionVenmoAccountDetailsWithOptions(t *testing.T) {
+	ctx := context.Background()
+
+	tx, err := testGateway.Transaction().Create(ctx, &TransactionRequest{
+		Type:               "sale",
+		Amount:             NewDecimal(2000, 2),
+		PaymentMethodNonce: FakeNonceVenmoAccount,
+		Options: &TransactionOptions{
+			TransactionOptionsVenmoRequest: &TransactionOptionsVenmoRequest{
+				ProfileId: profileId,
+			},
+		},
 	})
 
 	t.Log(tx)


### PR DESCRIPTION
### Description

In order for the Venmo charge transaction to be associated with the correct brand, we need to support sending the `profileId` which can be populated in the `TransactionOptionsVenmoRequest` part of the Options.

### Checklist
<!-- Tick with "x" the boxes that apply. You can also fill these out after creating the PR. -->
* [x] I've read the [contribution guidelines](CONTRIBUTING.md)
* [ ] I've added Unit Tests if necessary.
* [ ] I've checked whether additional documentation is needed.
* [x] I've ensured any personally identifying information is handled with the necessary care.
* [ ] I've checked if my implementation doesn't break other features.

