### PR TITLE
[PCON-3122]Adding prepaid field to the Apple Pay response.

### DIFF
--- a/apple_pay_card.go
+++ b/apple_pay_card.go
@@ -10,6 +10,7 @@ type ApplePayCard struct {
 	Token                 string         `xml:"token"`
 	ImageURL              string         `xml:"image-url"`
 	CardType              string         `xml:"card-type"`
+	Prepaid               string         `xml:"prepaid"`
 	PaymentInstrumentName string         `xml:"payment-instrument-name"`
 	SourceDescription     string         `xml:"source-description"`
 	BIN                   string         `xml:"bin"`


### PR DESCRIPTION
Based on the Braintree documentation, the "prepaid" field would contain information about whether or not the Apple Pay sourcing fund is a prepaid card. 
The possible values are: yes, no, unknown.

### Description
<!-- You can 1. describe what this pull request implements, 2. give an overview of the proposed solution, 3. add any further comments you might find important, such as why something is missing; whether there are dependencies for this to be merged. Feel free also to add demos (screenshots, videos) if you find that useful. -->

### Checklist
<!-- Tick with "x" the boxes that apply. You can also fill these out after creating the PR. -->
* [ ] I've read the [contribution guidelines](CONTRIBUTING.md)
* [ ] I've added Unit Tests if necessary.
* [ ] I've checked whether additional documentation is needed.
* [ ] I've ensured any personally identifying information is handled with the necessary care.
* [ ] I've checked if my implementation doesn't break other features.

