### PR TITLE
[PCON-3122]Adding prepaid field to the Apple Pay details.

### DIFF
--- a/apple_pay_details.go
+++ b/apple_pay_details.go
@@ -3,6 +3,7 @@ package braintree
 type ApplePayDetails struct {
 	Token                 string `xml:"token"`
 	CardType              string `xml:"card-type"`
+	Prepaid               string `xml:"prepaid"`
 	PaymentInstrumentName string `xml:"payment-instrument-name"`
 	SourceDescription     string `xml:"source-description"`
 	CardholderName        string `xml:"cardholder-name"`


### PR DESCRIPTION
Based on the Braintree documentation, the "prepaid" field would contain information about the Apple Pay sourcing fund being a prepaid card or not. The possible values are: yes, no, unknown.

### Description
<!-- You can 1. describe what this pull request implements, 2. give an overview of the proposed solution, 3. add any further comments you might find important, such as why something is missing; whether there are dependencies for this to be merged. Feel free also to add demos (screenshots, videos) if you find that useful. -->

### Checklist
<!-- Tick with "x" the boxes that apply. You can also fill these out after creating the PR. -->
* [ ] I've read the [contribution guidelines](CONTRIBUTING.md)
* [ ] I've added Unit Tests if necessary.
* [ ] I've checked whether additional documentation is needed.
* [ ] I've ensured any personally identifying information is handled with the necessary care.
* [ ] I've checked if my implementation doesn't break other features.

